### PR TITLE
allow users to define initialState as a function of props

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ The component returned by `connect()` expects to be passed the redux store as a 
 #### Arguments
   - `key` **Required**
     * *String*: Specifies the key on `state.ephemeral` where the component's local state will be mounted.
-    * *Function*: `id(props) -> String`. Accepts the component's props as an arguments and returns a string that specifies the key on `state.ephemeral` where the component's local state will be mounted.
-  - `reducer` **Required** 
+    * *Function*: `id(props) -> String`. Accepts the component's props as an argument and returns a string that specifies the key on `state.ephemeral` where the component's local state will be mounted.
+  - `reducer` **Required**
     * *Function*: `reducer(state, action) -> newState`. Reducer that accepts the local state and action as arguments and returns the new local state.
   - [`initialState`]
-    * The initial value of the component's local state. If you don't define this here, be sure to handle the possibility of undefined initial state when you write your reducer.
+    * *Function*: `initialState(props) -> value`. Accepts the component's props as an argument and returns the initial value of the component's local state.
+    * *Value*: The initial value of the component's local state. If you don't define this here, be sure to handle the possibility of undefined initial state when you write your reducer.
   - [`mapDispatchToProps`]
     * *Function*: `mapDispatchToProps(localDispatch, ownProps) -> dispatchProps`.
     * *Object*
@@ -27,7 +28,7 @@ The component returned by `connect()` expects to be passed the redux store as a 
   - [`mergeProps`]
     * *Function*: `mergeProps(dispatchProps, ephemeralProps, ownProps) -> mergedProps`. This function receives as arguments the result of `mapDispatchToProps`, the value stored at `state.ephemeral[key]`, and the props passed to the component by its parent. If you don't pass your own function as an argument to `connect`, it returns `Object.assign({}, ownProps, ephemeralProps, dispatchProps)` by default.
 
-    
+
 ## Purpose
 
 If you've built an app of significant size using React and Redux, you likely have struggled with the problem of managing state that is specific to a particular instance of a component. For example, imagine you're building a shopping cart, and each item in the cart has its own component. Each component has a toggleable description. Where should you store the values that represent whether each item's description is expanded or collapsed? Two options come to mind immediately - in the Redux store and in the tab component's state (i.e., `this.state`).

--- a/src/connect.js
+++ b/src/connect.js
@@ -110,6 +110,7 @@ export default function connect(config = {}) {
         const isKeyAlreadyMounted = stateAtKey !== undefined;
         const initial = (() => {
           if (isKeyAlreadyMounted) return stateAtKey;
+          if (typeof initialState === 'function') return initialState(this.props);
           if (initialState !== undefined) return initialState;
           return reducer(initialState, {});
         })();

--- a/test/connect.spec.js
+++ b/test/connect.spec.js
@@ -7,11 +7,11 @@ import TestUtils from 'react-addons-test-utils';
 import { connect, reducer as ephemeralReducer } from '../src';
 
 describe('connect', function () {
-  
+
   beforeEach(function () {
     expect.spyOn(console, 'error')
   });
-   
+
   afterEach(function () {
     expect.restoreSpies()
   });
@@ -87,6 +87,49 @@ describe('connect', function () {
     expect(stub.props.local).toBeAn(Object);
     expect(stub.props.local.test).toBe(true);
     expect(stub.props.local.notTest).toBe(undefined);
+
+  });
+
+  it('should initialize state as a function of props', function () {
+
+    const initialState = (props) => ({ test: props.testValue === 4 });
+
+    const store = createStore(globalReducer);
+
+    const ConnectedLocal = connect({
+      key: 'local',
+      reducer: localReducer,
+      initialState
+    })(Local);
+
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <ConnectedLocal testValue={4} />
+      </Provider>
+    );
+
+    const stub = TestUtils.findRenderedComponentWithType(tree, Local);
+
+    expect(stub.props.local).toBeAn(Object);
+    expect(stub.props.testValue).toBe(4);
+    expect(stub.props.local.test).toBe(true);
+
+    const ConnectedLocal2 = connect({
+      key: 'local2',
+      reducer: localReducer,
+      initialState
+    })(Local);
+
+    const tree2 = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <ConnectedLocal2 testValue={3} />
+      </Provider>
+    );
+
+    const stub2 = TestUtils.findRenderedComponentWithType(tree2, Local);
+
+    expect(stub2.props.testValue).toBe(3);
+    expect(stub2.props.local.test).toBe(false);
 
   });
 


### PR DESCRIPTION
Addresses Issue #2, allowing users to pass a function to initialize local state as a function of the props passed by the parent component.

@NHypothesis
